### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ lpass show example/my-secret --json
 ]
 ```
 
-Define a `LastPass` [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources) to automatically manage the lifecycle of your secrets in Kubernetes
+Define a `LastPass` or `LastPassGroup` [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources) to automatically manage the lifecycle of your secrets in Kubernetes
 ```bash
 $ cat example/edgelevel_v1alpha1_lastpass_cr.yaml
 apiVersion: edgelevel.com/v1alpha1
@@ -55,6 +55,27 @@ spec:
 
 # create a custom resource
 $ kubectl apply -f example/edgelevel_v1alpha1_lastpass_cr.yaml
+```
+_NOTE: The `LastPassGroup` custom resource will sync all the secrets in a lastpass folder to kubernetes. The lastpass group will **not** sync subfolders._
+```bash
+$ cat example/edgelevel_v1alpha1_lastpassgroup_cr.yaml
+apiVersion: edgelevel.com/v1alpha1
+kind: LastPassGroup
+metadata:
+  name: example-lastpassgruop
+spec:
+  secretRef:
+    group: example
+    withUsername: true
+    withPassword: true
+    withUrl: true
+    withNote: true
+  syncPolicy:
+    enabled: true
+    refresh: 10
+
+# create a custom resource
+$ kubectl apply -f example/edgelevel_v1alpha1_lastpassgroup_cr.yaml
 ```
 
 The operator will take care of create native Kubernetes secrets and keep them up to date that if they change
@@ -153,14 +174,20 @@ Run locally outside the cluster on [minkube](https://github.com/kubernetes/minik
 # requires virtualbox
 minikube start
 
-# apply crd
-kubectl apply -f chart/templates/crd.yaml
-
 # run locally
 export OPERATOR_NAME=lastpass-operator
 export LASTPASS_USERNAME=myUsername
 export LASTPASS_PASSWORD=myPassword
-operator-sdk up local --namespace=default --verbose
+
+# Install CRDs into cluster
+make install
+
+# Start lastpass operator
+make run
+
+# Alternatively you can install and run with
+make install run
+
 ```
 
 Run as a Deployment inside the cluster

--- a/docs/golang.md
+++ b/docs/golang.md
@@ -1,7 +1,6 @@
 ## golang
 
 * [go](https://golang.org/doc) documentation
-* [dep](https://golang.github.io/dep/docs/introduction.html) Dependency management for Go
 * [Convert JSON into a Go type definition](https://mholt.github.io/json-to-go/)
 
 ```bash
@@ -9,22 +8,15 @@
 mkdir -p $GOPATH/src/github.com/edgelevel && cd $_
 git clone git@github.com:edgelevel/lastpass-operator.git
 
-# first time only
-dep init
-
 # add dependencies
-dep ensure -add github.com/USER/DEP1 github.com/USER/DEP2
+go get github.com/USER/DEP1 github.com/USER/DEP2
 # example
-dep ensure -add github.com/spf13/cobra
-dep ensure -add github.com/codeskyblue/go-sh
+go get github.com/spf13/cobra
+go get github.com/codeskyblue/go-sh
 
 # verify and update all dependencies
-dep status
-dep check
-dep ensure -update
-
-# resolve dependencies
-dep ensure
+go get -u
+go mod tidy
 
 # init cli
 cobra init . --pkg-name lastpass-operator

--- a/docs/lastpass.md
+++ b/docs/lastpass.md
@@ -19,7 +19,7 @@ lpass show <GROUP>/<NAME> --json --expand-multi
 lpass logout --force
 ```
 
-Docker Alpine (8.07MB)
+Docker Alpine (20.1MB)
 ```bash
 # temporary base container
 docker run --rm -it alpine /bin/sh
@@ -33,7 +33,7 @@ echo <PASSWORD> | LPASS_DISABLE_PINENTRY=1 lpass login --trust <USERNAME>
 echo <PASSWORD> | lpass show <GROUP>/<NAME> --json --expand-multi
 ```
 
-Docker Ubuntu (673MB)
+Docker Ubuntu (192MB)
 ```bash
 # build image
 docker build -t edgelevel/lastpass-cli -f example/lastpass-ubuntu .

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,44 +1,66 @@
-## Setup
+# Setup
 
 * [docker](https://docs.docker.com/install)
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
 * [helm](https://helm.sh/docs/using_helm/#installing-helm)
 * [go](https://golang.org/doc)
-* [dep](https://golang.github.io/dep/docs/introduction.html)
 * [operator-sdk](https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md)
 * [minikube](https://github.com/kubernetes/minikube)
 
-Ubuntu
+## Ubuntu:
+
+Install docker using the instructions below from the [docker website](https://docs.docker.com/engine/install/ubuntu/#installation-methods)
 ```bash
-# docker
-sudo snap install docker
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
 
-# kubectl
-sudo snap install kubectl --classic
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
 
-# helm
-sudo snap install helm --classic
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
 
-# go
-sudo snap install --classic go
+### kubectl: 
 
-# dep
-curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+`sudo snap install kubectl --classic`
 
+### helm: 
+
+`sudo snap install helm --classic`
+
+### go:
+
+`sudo snap install go --classic`
+
+
+### Operator-SDK:
+```bash
 # operator-sdk (from source)
 go get -d github.com/operator-framework/operator-sdk
 cd $GOPATH/src/github.com/operator-framework/operator-sdk
 git checkout master
 make dep
 make install
+```
+Alternatively, you can use the operator-sdk build dependency that is in the `bin` directory. This operator-sdk binary can be downloaded using:
 
-# minikube
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && \
-  chmod +x minikube && \
-  sudo mv minikube /usr/local/bin/
+`make operator-sdk`
+
+### minikube
+```bash
+curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+sudo install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
 ```
 
-macOS
+## macOS
 ```bash
 # docker
 # download from https://hub.docker.com/editions/community/docker-ce-desktop-mac
@@ -51,9 +73,6 @@ brew install kubernetes-helm
 
 # go
 brew install go
-
-# dep
-brew install dep
 
 # operator-sdk
 brew install operator-sdk

--- a/example/lastpass-alpine
+++ b/example/lastpass-alpine
@@ -1,5 +1,35 @@
-FROM alpine:latest
+FROM alpine:latest AS builder
+
+ENV LASTPASS_VERSION=1.5.0
 
 RUN apk add --update --no-cache \
-  lastpass-cli && \
-  rm -f /var/cache/apk/*
+    bash-completion \
+    cmake \
+    curl-dev \
+    openssl-dev \
+    libxml2 \
+    libxml2-dev \
+    libssl3 \
+    pkgconf \
+    ca-certificates \
+    xclip \
+    g++ \
+    make \
+    wget
+
+RUN wget -O lastpass-cli.tar.gz https://github.com/lastpass/lastpass-cli/releases/download/v${LASTPASS_VERSION}/lastpass-cli-${LASTPASS_VERSION}.tar.gz; \
+    tar -xf lastpass-cli.tar.gz
+
+WORKDIR /lastpass-cli-${LASTPASS_VERSION}
+
+RUN make && make install
+
+RUN mkdir -p /usr/lib/lastpass-cli \
+    && ldd /usr/bin/lpass | grep '=>' | awk '{ print $3 }' | xargs cp -t /usr/lib/lastpass-cli
+
+
+
+FROM alpine:latest 
+
+COPY --from=builder /usr/bin/lpass /usr/bin/which /usr/bin/
+COPY --from=builder /usr/lib/lastpass-cli /lib

--- a/example/lastpass-ubuntu
+++ b/example/lastpass-ubuntu
@@ -1,19 +1,36 @@
-FROM phusion/baseimage:latest
+FROM ubuntu:22.04 AS builder
 
-RUN apt-get update && apt-get upgrade -y
+ENV LASTPASS_VERSION=1.5.0
 
-RUN apt-get update && apt-get --no-install-recommends install -y \
-  bash-completion \
-  build-essential \
-  cmake \
-  libcurl3  \
-  libcurl3-openssl-dev  \
-  libssl1.0.0 \
-  libssl-dev \
-  libxml2 \
-  libxml2-dev  \
-  pkg-config \
-  ca-certificates \
-  xclip \
-  lastpass-cli && \
-  apt-get clean
+# https://github.com/lastpass/lastpass-cli?tab=readme-ov-file#building
+RUN apt update && apt --no-install-recommends -yqq install \
+    bash-completion \
+    build-essential \
+    cmake \
+    libcurl4  \
+    libcurl4-openssl-dev  \
+    libssl-dev  \
+    libxml2 \
+    libxml2-dev  \
+    libssl3 \
+    pkg-config \
+    ca-certificates \
+    xclip \
+    wget
+
+RUN wget -O lastpass-cli.tar.gz https://github.com/lastpass/lastpass-cli/releases/download/v${LASTPASS_VERSION}/lastpass-cli-${LASTPASS_VERSION}.tar.gz; \
+    tar -xf lastpass-cli.tar.gz
+
+WORKDIR /lastpass-cli-${LASTPASS_VERSION}
+
+RUN make && make install
+
+RUN mkdir -p /usr/lib/lastpass-cli \
+&& ldd /usr/bin/lpass | grep '=>' | awk '{ print $3 }' | xargs cp -t /usr/lib/lastpass-cli
+
+FROM ubuntu:22.04
+
+RUN apt update && apt --no-install-recommends -yqq install ca-certificates
+
+COPY --from=builder /usr/bin/lpass /usr/bin/which /usr/bin/
+COPY --from=builder /usr/lib/lastpass-cli /lib


### PR DESCRIPTION
Changelog:

* Update development section in project readme
* Update docs/setup to use docker installation methods as snap no longer provides latest docker versions
* Remove `go deps` from docs/setup and docs/golang as `deps` is deprecated
* Update example lastpass containers to build latest version of lastpass-cli